### PR TITLE
Reset dragCount on drop event

### DIFF
--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -50,6 +50,7 @@ export default {
       }
     },
     handleDrop({ dataTransfer: { files } }) {
+      this.dragCount = 0;
       this.$emit('dropped');
       this.client.upload(Array.from(files));
     },

--- a/tests/unit/drop-zone.spec.js
+++ b/tests/unit/drop-zone.spec.js
@@ -75,6 +75,18 @@ describe('DropZone', () => {
       { args: [], name: 'entered' },
       { args: [], name: 'dropped' },
     ]);
+
+    // Check that entered event is fired after drop
+    w.trigger('dragenter');
+    expect(w.emittedByOrder()).toEqual([
+      { args: [[]], name: 'input' },
+      { args: [[]], name: 'input' },
+      { args: [], name: 'entered' },
+      { args: [], name: 'left' },
+      { args: [], name: 'entered' },
+      { args: [], name: 'dropped' },
+      { args: [], name: 'entered' },
+    ]);
   });
 
   test('emits input events for every store change', async () => {


### PR DESCRIPTION
DragCount should be reset on drop event, otherwise the `entered` event won't be fired after the first drop.