### PR TITLE
Support multiple drop zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ by the client itself.
 - entered: Triggers when the mouse pointer enters the dropping area
 - left: Triggers when the mouse poiter has left the dropping area
 - dropped: Triggers when the files are dropped
+- success: Triggers when the upload successfully finished
+- error(File file): Triggers when the upload fails. Also provides the file
+that failed the first as an event argument.
 
 ## Development
 ```

--- a/README.md
+++ b/README.md
@@ -48,13 +48,15 @@ import { DropZone } from '@4tw/vue-drop-zone'
 
 ### Uppy Client
 
-The client is a singleton and can be imported from the library:
+The client sits on every drop-zone instance and can be retrieved using a ref:
+
+``` html
+<DropZone ref="dropzone" />
+```
 
 ``` javascript
-import { client } from '@4tw/vue-drop-zone'
-
-client.uppy.pauseAll();
-client.uppy.retryAll();
+this.$refs.dropzone.client.uppy.pauseAll();
+this.$refs.dropzone.client.uppy.retryAll();
 ```
 
 See https://uppy.io/docs/uppy/#Methods for all the available methods.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --name drop-zone src/index.js",
+    "build": "vue-cli-service build --target lib --name drop-zone src/components/DropZone.vue",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit",
     "preversion": "yarn run lint && yarn run test:unit && yarn run build",

--- a/src/client.js
+++ b/src/client.js
@@ -30,32 +30,32 @@ const MODE_MAPPING = {
   XHR: { uploader: XHR },
 };
 
-const client = {
+export default class Client {
+  constructor(vm, options = {}) {
+    this.uppy = createUppyClient(vm, options.uppy);
+    this.installPlugin(options.uploader, options.mode);
+  }
+
   installPlugin(options = {}, mode = 'TUS') {
     this.uppy.use(
       MODE_MAPPING[mode].uploader,
       Object.assign(MODE_MAPPING[mode].options || {}, options),
     );
-  },
-  init(vm, options = {}) {
-    this.uppy = createUppyClient(vm, options.uppy);
-    this.installPlugin(options.uploader, options.mode);
-  },
+  }
+
   reset(options = {}) {
     if (this.uppy) {
       this.uppy.close();
       this.installPlugin(options, options.mode);
     }
-  },
+  }
+
   async upload(files = []) {
-    if (!this.uppy) { throw new Error('Client has not been initialized'); }
     files.forEach(f => this.addFile(f));
     return this.uppy.upload();
-  },
-  addFile(file) {
-    if (!this.uppy) { throw new Error('Client has not been initialized'); }
-    this.uppy.addFile({ name: file.name, type: file.type, data: file });
-  },
-};
+  }
 
-export default client;
+  addFile(file) {
+    this.uppy.addFile({ name: file.name, type: file.type, data: file });
+  }
+}

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -71,7 +71,8 @@ export default {
       this.options,
       { uploader: { endpoint: this.endpoint }, mode: this.mode },
     );
-    this.client.init(this, options);
+    this.client.uppy.on('upload-error', file => this.$emit('error', file));
+    this.client.uppy.on('upload-success', () => this.$emit('success'));
   },
   destroyed() {
     window.removeEventListener('dragover', this.preventDefault);

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -8,14 +8,16 @@
 
 <script>
 import merge from 'lodash/merge';
-import client from '../client';
+import Client from '../client';
+
+const UPLOAD_MODES = ['TUS', 'XHR'];
 
 export default {
   name: 'DropZone',
   data() {
     return {
       dragCount: 0,
-      client,
+      client: null,
     };
   },
   props: {
@@ -30,7 +32,7 @@ export default {
     mode: {
       type: String,
       default: () => 'TUS',
-      validator: m => ['TUS', 'XHR'].includes(m),
+      validator: m => UPLOAD_MODES.includes(m),
     },
     options: {
       type: Object,
@@ -50,10 +52,10 @@ export default {
         this.$emit('left');
       }
     },
-    handleDrop({ dataTransfer: { files } }) {
+    async handleDrop({ dataTransfer: { files } }) {
       this.dragCount = 0;
       this.$emit('dropped');
-      this.client.upload(Array.from(files));
+      await this.client.upload(Array.from(files));
     },
     preventDefault(e) { e.preventDefault(); },
   },
@@ -71,6 +73,7 @@ export default {
       this.options,
       { uploader: { endpoint: this.endpoint }, mode: this.mode },
     );
+    this.client = new Client(this, options);
     this.client.uppy.on('upload-error', file => this.$emit('error', file));
     this.client.uppy.on('upload-success', () => this.$emit('success'));
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,0 @@
-import client from './client';
-import DropZone from './components/DropZone.vue';
-
-export {
-  client,
-  DropZone,
-};

--- a/tests/unit/client.spec.js
+++ b/tests/unit/client.spec.js
@@ -1,4 +1,4 @@
-import client from '@/client';
+import Client from '@/client';
 import Vue from 'vue';
 
 function assertFiles(c, expected) {
@@ -8,18 +8,14 @@ function assertFiles(c, expected) {
 }
 
 describe('client', () => {
-  afterEach(() => {
-    client.reset();
-    delete client.uppy;
-  });
-
   test('throws error when no vm is provided', () => {
-    expect(() => { client.init(); })
+    // eslint-disable-next-line no-new
+    expect(() => { new Client(); })
       .toThrowError(new Error('No vue instance is provided'));
   });
 
   test('initializes uppy client', () => {
-    client.init(new Vue());
+    const client = new Client(new Vue());
     expect(client.uppy).not.toBeUndefined();
 
     // Installs tus plugin
@@ -30,7 +26,7 @@ describe('client', () => {
   });
 
   test('accepts uploader options', () => {
-    client.init(new Vue());
+    const client = new Client(new Vue());
     expect(client.uppy.getPlugin('Tus').opts)
       .toEqual({
         resume: false,
@@ -41,8 +37,8 @@ describe('client', () => {
         headers: { Accept: 'application/json' },
       });
 
-    client.init(new Vue(), { uploader: { resume: true } });
-    expect(client.uppy.getPlugin('Tus').opts)
+    const clientWithOptions = new Client(new Vue(), { uploader: { resume: true } });
+    expect(clientWithOptions.uppy.getPlugin('Tus').opts)
       .toEqual({
         resume: true,
         autoRetry: true,
@@ -54,32 +50,21 @@ describe('client', () => {
   });
 
   test('accepts uppy options', () => {
-    client.init(new Vue());
+    const client = new Client(new Vue());
     expect(client.uppy.opts.meta).toEqual({});
 
-    client.init(new Vue(), { uppy: { meta: { some: 'meta' } } });
-    expect(client.uppy.opts.meta).toEqual({ some: 'meta' });
-  });
-
-  test('adding a file throws when uppy is not initialized', () => {
-    expect(() => { client.addFile(); })
-      .toThrowError(new Error('Client has not been initialized'));
+    const clientWithMeta = new Client(new Vue(), { uppy: { meta: { some: 'meta' } } });
+    expect(clientWithMeta.uppy.opts.meta).toEqual({ some: 'meta' });
   });
 
   test('adds files to the store', () => {
-    client.init(new Vue());
+    const client = new Client(new Vue());
     client.addFile({ name: 'file', type: 'image/png', data: '' });
     assertFiles(client, ['file']);
   });
 
-  test('upload throws error when client is not initialized', () => {
-    expect(client.upload())
-      .rejects
-      .toEqual(new Error('Client has not been initialized'));
-  });
-
   test('resets uppy client', () => {
-    client.init(new Vue(), { uploader: { resume: true } });
+    const client = new Client(new Vue(), { uploader: { resume: true } });
     client.addFile({ name: 'file', type: 'image/png', data: '' });
     assertFiles(client, ['file']);
     expect(client.uppy.getPlugin('Tus').opts)
@@ -107,7 +92,7 @@ describe('client', () => {
 
   test('supports tus and xhr upload', () => {
     // Default is tus
-    client.init(new Vue());
+    const client = new Client(new Vue());
     expect(client.uppy.plugins.uploader.map(u => u.title))
       .toEqual(['Tus']);
 

--- a/tests/unit/drop-zone.spec.js
+++ b/tests/unit/drop-zone.spec.js
@@ -1,5 +1,4 @@
 import DropZone from '@/components/DropZone.vue';
-import client from '@/client';
 import { localMount } from './support';
 import { flatMap } from 'lodash';
 
@@ -65,14 +64,47 @@ describe('DropZone', () => {
       { args: [], name: 'entered' },
     ]);
 
+    w.vm.client.addFile({ name: 'file1', data: '' });
+
     // Check the drop event
     w.trigger('drop', { dataTransfer: { files: [] } });
+
+    const inputEvent = [
+      {
+        data: {
+          data: '',
+          name: 'file1',
+        },
+        extension: '',
+        id: 'uppy-file1',
+        isRemote: false,
+        meta: {
+          name: 'file1',
+          type: 'application/octet-stream',
+        },
+        name: 'file1',
+        preview: undefined,
+        progress: {
+          bytesTotal: 0,
+          bytesUploaded: 0,
+          percentage: 0,
+          uploadComplete: false,
+          uploadStarted: false,
+        },
+        remote: '',
+        size: 0,
+        source: '',
+        type: 'application/octet-stream',
+      },
+    ];
+
     expect(w.emittedByOrder()).toEqual([
       { args: [[]], name: 'input' },
       { args: [[]], name: 'input' },
       { args: [], name: 'entered' },
       { args: [], name: 'left' },
       { args: [], name: 'entered' },
+      { args: [inputEvent], name: 'input' },
       { args: [], name: 'dropped' },
     ]);
 
@@ -84,6 +116,7 @@ describe('DropZone', () => {
       { args: [], name: 'entered' },
       { args: [], name: 'left' },
       { args: [], name: 'entered' },
+      { args: [inputEvent], name: 'input' },
       { args: [], name: 'dropped' },
       { args: [], name: 'entered' },
     ]);
@@ -92,27 +125,27 @@ describe('DropZone', () => {
   test('emits input events for every store change', async () => {
     assertUppyFiles(w, []);
 
-    w.vm.client.uppy.addFile({ name: 'file1', data: '' });
+    w.vm.client.addFile({ name: 'file1', data: '' });
     expect(w.emittedByOrder().length).toBe(3);
     expect(w.emittedByOrder().map(e => e.name)).toEqual(['input', 'input', 'input']);
     assertUppyFiles(w, ['file1']);
 
-    w.vm.client.uppy.addFile({ name: 'file2', data: '' });
+    w.vm.client.addFile({ name: 'file2', data: '' });
     expect(w.emittedByOrder().length).toBe(4);
     expect(w.emittedByOrder().map(e => e.name)).toEqual(['input', 'input', 'input', 'input']);
     assertUppyFiles(w, ['file1', 'file1', 'file2']);
   });
 
   test('control the drop zone with the client', () => {
-    client.uppy.addFile({ name: 'file1', data: '' });
+    w.vm.client.addFile({ name: 'file1', data: '' });
     expect(w.emittedByOrder().length).toBe(3);
     expect(w.emittedByOrder().map(e => e.name)).toEqual(['input', 'input', 'input']);
     assertUppyFiles(w, ['file1']);
 
-    client.uppy.reset();
+    w.vm.client.reset();
     // This event is still here when the file was added
     assertUppyFiles(w, ['file1']);
-    expect(client.uppy.getState().files).toEqual({});
+    expect(w.vm.client.uppy.getState().files).toEqual({});
   });
 
   test('run the drop zone in XHR mode', async () => {
@@ -120,7 +153,7 @@ describe('DropZone', () => {
     w.setProps({ mode: 'XHR' });
 
     await w.vm.$nextTick();
-    expect(client.uppy.plugins.uploader.map(u => u.title))
+    expect(w.vm.client.uppy.plugins.uploader.map(u => u.title))
       .toEqual(['XHRUpload']);
   });
 });


### PR DESCRIPTION
Because there are multiple drop zones the client is no longer a singleton. So every dropzone components hold its own client which can be retrieved through a reference.

Also, provide error and success events.