### PR TITLE
Add precondition check

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -8,7 +8,9 @@ function isFile(file) {
   return new Promise((resolve, reject) => {
     reader.onerror = () => {
       reader.abort();
-      reject(new Error('No folders allowed'));
+      const error = new Error('Upload canceled because folders cannot be uploaded');
+      error.name = 'FoldersNotAllowedError';
+      reject(error);
     };
     reader.onload = () => {
       resolve(true);
@@ -58,7 +60,7 @@ export default class Client {
   reset(options = {}) {
     if (this.uppy) {
       this.uppy.close();
-      this.installPlugin(options, options.mode);
+      this.installPlugin(options.uploader, options.mode);
     }
   }
 

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -54,6 +54,10 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    precondition: {
+      type: Function,
+      default: () => true,
+    },
   },
   methods: {
     handleDragEnter() {
@@ -78,7 +82,13 @@ export default {
     },
     async handleUpload(files) {
       try {
-        await this.client.upload(Array.from(files));
+        if (await this.precondition()) {
+          await this.client.upload(Array.from(files));
+        } else {
+          const error = new Error('Upload canceled because precondition check failed');
+          error.name = 'PreconditionFailure';
+          throw error;
+        }
       } catch (error) {
         this.$emit('error', error);
       }


### PR DESCRIPTION
The precondition is evaluated before files are added to Uppy and before the upload starts. This way preconditions can be better differentiated from file parsing errors or errors that happen while the upload is in progress. If the precondition returns `false` the upload won't start.

Also fixed an error in the client `reset` method. Instead of passing the whole `options` object to the `installPlugin` method, only the `uploader` property is required.