### PR TITLE
Don't reset Uppy client when endpont changes

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -55,6 +55,10 @@ export default class Client {
     );
   }
 
+  updateEndpoint(endpoint, { mode = 'TUS' } = {}) {
+    this.uppy.getPlugin(MODE_MAPPING[mode].uploader.name).opts.endpoint = endpoint;
+  }
+
   reset(options = {}) {
     if (this.uppy) {
       this.uppy.close();

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -108,7 +108,7 @@ export default {
     window.removeEventListener('drop', this.preventDefault);
   },
   watch: {
-    endpoint(endpoint) { this.client.reset(merge(this.options, { uploader: { endpoint } })); },
+    endpoint(endpoint) { this.client.updateEndpoint(endpoint, this.options); },
     mode(mode) { this.client.reset(merge(this.options, { mode })); },
   },
 };

--- a/tests/unit/client.spec.js
+++ b/tests/unit/client.spec.js
@@ -100,4 +100,12 @@ describe('client', () => {
     expect(client.uppy.plugins.uploader.map(u => u.title))
       .toEqual(['XHRUpload']);
   });
+
+  test('changes endpoint', () => {
+    const client = new Client(new Vue(), { uploader: { endpoint: 'path1' } });
+    expect(client.uppy.getPlugin('Tus').opts.endpoint).toBe('path1');
+
+    client.updateEndpoint('path2');
+    expect(client.uppy.getPlugin('Tus').opts.endpoint).toBe('path2');
+  });
 });


### PR DESCRIPTION
Now the user can change the context without the upload being canceled. It is even possible to upload a new file to the new endpoint while an upload to the old endpoint is still in progress.