### PR TITLE
Allow duplicate file uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-jest": "^23.6.0",
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0-0",
+    "mockdate": "^2.0.2",
     "require-context": "^1.1.0",
     "vue-template-compiler": "^2.5.17"
   },

--- a/src/client.js
+++ b/src/client.js
@@ -2,6 +2,7 @@ import Uppy from '@uppy/core';
 import Tus from '@uppy/tus';
 import XHR from '@uppy/xhr-upload';
 import VueStore from './vuestore';
+import { updateLastModified } from './utils';
 
 function isFile(file) {
   const reader = new FileReader();
@@ -73,6 +74,6 @@ export default class Client {
   }
 
   addFile(file) {
-    this.uppy.addFile({ name: file.name, type: file.type, data: file });
+    this.uppy.addFile({ name: file.name, type: file.type, data: updateLastModified(file) });
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -9,7 +9,9 @@ function isFile(file) {
   return new Promise((resolve, reject) => {
     reader.onerror = () => {
       reader.abort();
-      reject(new Error('No folders allowed'));
+      const error = new Error('Upload canceled because folders cannot be uploaded');
+      error.name = 'FoldersNotAllowedError';
+      reject(error);
     };
     reader.onload = () => {
       resolve(true);

--- a/src/client.js
+++ b/src/client.js
@@ -63,7 +63,7 @@ export default class Client {
   reset(options = {}) {
     if (this.uppy) {
       this.uppy.close();
-      this.installPlugin(options, options.mode);
+      this.installPlugin(options.uploader, options.mode);
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,3 +19,10 @@ export function resolveComponents(components) {
     return { component: component.default || component, name, fileName };
   });
 }
+
+export function updateLastModified(file) {
+  return new File([file], file.name, {
+    type: file.type,
+    lastModified: new Date().getTime(),
+  });
+}

--- a/tests/unit/drop-zone.spec.js
+++ b/tests/unit/drop-zone.spec.js
@@ -1,5 +1,5 @@
 import DropZone from '@/components/DropZone.vue';
-import { localMount } from './support';
+import { localMount, freezeTime } from './support';
 import { flatMap } from 'lodash';
 
 function assertUppyFiles(w, expected) {
@@ -13,9 +13,11 @@ function assertUppyFiles(w, expected) {
 
 describe('DropZone', () => {
   let w;
+  let now;
 
   beforeEach(async () => {
     w = await localMount(DropZone);
+    now = freezeTime();
   });
 
   test('Component renders', () => {
@@ -64,23 +66,21 @@ describe('DropZone', () => {
       { args: [], name: 'entered' },
     ]);
 
-    w.vm.client.addFile({ name: 'file1', data: '' });
+    const file = new File([''], 'file1', { type: 'text' });
+    w.vm.client.addFile(file);
 
     // Check the drop event
     w.trigger('drop', { dataTransfer: { files: [] } });
 
     const inputEvent = [
       {
-        data: {
-          data: '',
-          name: 'file1',
-        },
+        data: file,
         extension: '',
-        id: 'uppy-file1',
+        id: `uppy-file1-text-${now}`,
         isRemote: false,
         meta: {
           name: 'file1',
-          type: 'application/octet-stream',
+          type: 'text',
         },
         name: 'file1',
         preview: undefined,
@@ -94,7 +94,7 @@ describe('DropZone', () => {
         remote: '',
         size: 0,
         source: '',
-        type: 'application/octet-stream',
+        type: 'text',
       },
     ];
 

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Vuetify from 'vuetify';
+import MockDate from 'mockdate';
 import { createLocalVue } from '@vue/test-utils';
 import { resolveComponents } from '@/utils';
 import requireContext from 'require-context';
@@ -44,4 +45,5 @@ global.beforeEach(() => {
     localVue.component(name, component);
   });
   global.localVue = localVue;
+  MockDate.reset();
 });

--- a/tests/unit/support/index.js
+++ b/tests/unit/support/index.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import MockDate from 'mockdate';
 import { mount, shallowMount } from '@vue/test-utils';
 
 function createAppContainer() {
@@ -43,4 +44,10 @@ export async function localShallow(component, options = {}) {
   });
   await Vue.nextTick();
   return wrapper;
+}
+
+export function freezeTime() {
+  const now = new Date().getTime();
+  MockDate.set(now);
+  return now;
 }

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -1,0 +1,11 @@
+import { updateLastModified } from '@/utils';
+
+describe('utils', () => {
+  test('modifies last modified date', () => {
+    const now = new Date(Date.now() - 5).getTime();
+    const file = new File([], 'test', { type: 'text', lastModified: now });
+
+    const modifiedFile = updateLastModified(file);
+    expect(modifiedFile.lastModified).not.toBe(file.lastModified);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6443,6 +6443,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
+  integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
User can now upload the same file twice. This is especially useful if the user wants to upload the same file to different endpoints.

Also fixed an error in the client `reset` method. Instead of passing the whole `options` object to the `installPlugin` method, only the `uploader` property is required.

Also changed the no folders error to be more verbose and added an error name `FoldersNotAllowedError`.