### PR TITLE
Fix production build

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -35,6 +35,7 @@ function createUppyClient(vm, options = {}) {
 
 const MODE_MAPPING = {
   TUS: {
+    id: 'Tus',
     uploader: Tus,
     options: {
       headers: { Accept: 'application/json' },
@@ -42,8 +43,15 @@ const MODE_MAPPING = {
       resume: false,
     },
   },
-  XHR: { uploader: XHR },
+  XHR: {
+    uploader: XHR,
+    id: 'XHRUpload',
+  },
 };
+
+export const MODES = Object.keys(MODE_MAPPING);
+
+export const DEFAULT_MODE = 'TUS';
 
 export default class Client {
   constructor(vm, options = {}) {
@@ -51,15 +59,15 @@ export default class Client {
     this.installPlugin(options.uploader, options.mode);
   }
 
-  installPlugin(options = {}, mode = 'TUS') {
+  installPlugin(options = {}, mode = DEFAULT_MODE) {
     this.uppy.use(
       MODE_MAPPING[mode].uploader,
       Object.assign(MODE_MAPPING[mode].options || {}, options),
     );
   }
 
-  updateEndpoint(endpoint, { mode = 'TUS' } = {}) {
-    this.uppy.getPlugin(MODE_MAPPING[mode].uploader.name).opts.endpoint = endpoint;
+  updateEndpoint(endpoint, { mode = DEFAULT_MODE } = {}) {
+    this.uppy.getPlugin(MODE_MAPPING[mode].id).opts.endpoint = endpoint;
   }
 
   reset(options = {}) {

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -19,9 +19,7 @@
 <script>
 import uuidv4 from 'uuid/v4';
 import merge from 'lodash/merge';
-import Client from '../client';
-
-const UPLOAD_MODES = ['TUS', 'XHR'];
+import Client, { MODES, DEFAULT_MODE } from '../client';
 
 export default {
   name: 'DropZone',
@@ -43,8 +41,8 @@ export default {
     },
     mode: {
       type: String,
-      default: () => 'TUS',
-      validator: m => UPLOAD_MODES.includes(m),
+      default: () => DEFAULT_MODE,
+      validator: m => MODES.includes(m),
     },
     options: {
       type: Object,


### PR DESCRIPTION
In production build, the plugin's id is minified to something like `e`. We need this id to identify the plugin in runtime to switch between different upload modes.
In order to identify the plugin properly, we define the id by ourselves in the MODE_MAPPING object.