### PR TITLE
Add single file upload mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ import DropZone from '@4tw/vue-drop-zone'
 - v-model[Array:[]]: Use the v-model to have a list of uppy files in the current state (https://uppy.io/docs/uppy/#uppy-getFile-fileID)
 - file-browser[Boolean:false]: Define if the dropzone should also be clickable to allow the user
 to select the files using the native file browser.
+- multiple[Boolean:true]: Define if multiple files can be uploaded.
 
 ### Uppy Client
 

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -9,7 +9,7 @@
         v-if="fileBrowser"
         :id="uuid"
         @change="handleFileInput"
-        multiple
+        :multiple="multiple"
         type="file"
         style="display: none;" />
     <slot />
@@ -52,6 +52,10 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    multiple: {
+      type: Boolean,
+      default: () => true,
+    },
   },
   methods: {
     handleDragEnter({ dataTransfer: { types } }) {
@@ -75,7 +79,12 @@ export default {
 
       this.dragCount = 0;
       this.$emit('dropped');
-      this.handleUpload(files);
+
+      if (!this.multiple && files.length > 1) {
+        this.$emit('maxFilesExceeded');
+      } else {
+        this.handleUpload(files);
+      }
     },
     handleFileInput({ target: { files } }) {
       this.handleUpload(files);


### PR DESCRIPTION
This is a requirement for RIS. Single files can be replaced (https://github.com/4teamwork/ris/issues/1382), so the `multiple` attribute must be configurable.

Also see the PR: https://github.com/4teamwork/ris/pull/1925

I decided against a `maxFiles` like API, as this simple flag should be good enough.