### PR TITLE
Allow to extend the uppy client with plugins

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/erbium

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -50,6 +50,15 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    /**
+     * A list of uppy plugins in the format:
+     * [PluginClass] or
+     * [[PluginClass, PluginOptions]] if providing plugin options
+     */
+    plugins: {
+      type: Array,
+      default: () => ([]),
+    },
     fileBrowser: {
       type: Boolean,
       default: () => false,
@@ -127,6 +136,7 @@ export default {
       { uploader: { endpoint: this.endpoint }, mode: this.mode },
     );
     this.client = new Client(this, options);
+    this.plugins.forEach(plugin => this.client.uppy.use(...[plugin].flatMap(p => p)));
     this.client.uppy.on('upload-error', file => this.$emit('error', file));
     this.client.uppy.on('upload-success', () => this.$emit('success'));
   },

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -74,7 +74,7 @@ export default {
   },
   methods: {
     handleDragEnter({ dataTransfer: { types } }) {
-      if (this.disabled) return
+      if (this.disabled) return;
       if (!types.includes('Files')) { return; }
 
       if (this.dragCount === 0) {
@@ -83,7 +83,7 @@ export default {
       this.dragCount += 1;
     },
     handleDragLeave({ dataTransfer: { types } }) {
-      if (this.disabled) return
+      if (this.disabled) return;
       if (!types.includes('Files')) { return; }
 
       this.dragCount -= 1;
@@ -92,7 +92,7 @@ export default {
       }
     },
     handleDrop({ dataTransfer: { files, types } }) {
-      if (this.disabled) return
+      if (this.disabled) return;
       if (!types.includes('Files')) { return; }
 
       this.dragCount = 0;
@@ -105,7 +105,7 @@ export default {
       }
     },
     handleFileInput({ target: { files } }) {
-      if (this.disabled) return
+      if (this.disabled) return;
       this.handleUpload(files);
     },
     async handleUpload(files) {

--- a/tests/unit/drop-zone.spec.js
+++ b/tests/unit/drop-zone.spec.js
@@ -206,4 +206,55 @@ describe('DropZone', () => {
     expect(w.find('input').attributes('disabled')).toEqual('disabled');
     expect(w.find('label').classes()).toEqual(['disabled']);
   });
+
+  test('can extend the uppy client with a plugin', async () => {
+    const installFunction = jest.fn();
+    function ExamplePlugin() {
+      return {
+        id: 'example-plugin',
+        type: 'example',
+        install: installFunction,
+      };
+    }
+    w = await localMount(DropZone, { propsData: { plugins: [ExamplePlugin] } });
+
+    expect(installFunction).toHaveBeenCalled();
+  });
+
+  test('can extend the uppy client with multiple plugins', async () => {
+    const installFunction = jest.fn();
+    function ExamplePlugin1() {
+      return {
+        id: 'example-plugin-1',
+        type: 'example',
+        install: installFunction,
+      };
+    }
+    function ExamplePlugin2() {
+      return {
+        id: 'example-plugin-2',
+        type: 'example',
+        install: installFunction,
+      };
+    }
+    w = await localMount(DropZone, { propsData: { plugins: [ExamplePlugin1, ExamplePlugin2] } });
+
+    expect(installFunction).toHaveBeenCalledTimes(2);
+  });
+
+  test('can extend provided plugins with options', async () => {
+    const options = { option1: 'option-1' };
+    const providedOpts = jest.fn();
+    function ExamplePlugin(uppy, opts) {
+      providedOpts(opts);
+      return {
+        id: 'example-plugin',
+        type: 'example',
+        install: () => {},
+      };
+    }
+    w = await localMount(DropZone, { propsData: { plugins: [[ExamplePlugin, options]] } });
+
+    expect(providedOpts).toHaveBeenCalledWith(options);
+  });
 });


### PR DESCRIPTION
This PR extends the `DropZone` component with a `plugins` prop.

This allows us to extend the underlying uppy-client with one or more plugins.

Related Uppy documentation: https://uppy.io/docs/uppy/#uppy-use-plugin-opts