### PR TITLE
Make the DropZone more extendable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@ import DropZone from '@4tw/vue-drop-zone'
 ### Properties
 
 - endpoint[String:document.URL]: Describes the endpoint where the dropzone should upload the files to
-- mode[String:'TUS']: Describes the uploader to be used. Can either be 'TUS' or 'XHR'.
+- uploader[Object:{ uploader:Class, options:Object }]: Describes the uploader to be used. Uppy already provides two uploaders for XHR: https://uppy.io/docs/xhr-upload/#Options or TUS: https://uppy.io/docs/tus/#Options.
 - options[Object:{}]:
   - uppy[Object:{}] for the uppy client options (https://uppy.io/docs/uppy/#Options),
-  - uploader[Object:{}] for the uploader options (XHR: https://uppy.io/docs/xhr-upload/#Options), (TUS: https://uppy.io/docs/tus/#Options)
   - preventUpload[Boolean:false] when set to true, the upload is not triggered automatically when dropping a file
 - v-model[Array:[]]: Use the v-model to have a list of uppy files in the current state (https://uppy.io/docs/uppy/#uppy-getFile-fileID)
 - file-browser[Boolean:false]: Define if the dropzone should also be clickable to allow the user

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@uppy/core": "^1.4.0",
     "@uppy/tus": "^1.4.0",
-    "@uppy/xhr-upload": "^1.3.0",
     "lodash": "^4.17.15",
     "uuid": "^3.3.3"
   },
@@ -32,6 +31,7 @@
     "@vue/cli-service": "^3.11.0",
     "@vue/eslint-config-airbnb": "^4.0.1",
     "@vue/test-utils": "^1.0.0-beta.20",
+    "@uppy/xhr-upload": "^1.3.0",
     "axios-mock-adapter": "^1.17.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",

--- a/src/components/DropZone.vue
+++ b/src/components/DropZone.vue
@@ -138,7 +138,7 @@ export default {
     this.client = new Client(this, options);
     this.plugins.forEach(plugin => this.client.uppy.use(...[plugin].flatMap(p => p)));
     this.client.uppy.on('upload-error', file => this.$emit('error', file));
-    this.client.uppy.on('upload-success', () => this.$emit('success'));
+    this.client.uppy.on('upload-success', (...props) => this.$emit('success', ...props));
   },
   destroyed() {
     window.removeEventListener('dragover', this.preventDefault);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import path from 'path';
-import { upperFirst, camelCase } from 'lodash';
+import upperFirst from 'lodash/upperFirst';
+import camelCase from 'lodash/camelCase';
 
 export function toPascalCase(string) {
   return upperFirst(camelCase(string));

--- a/tests/unit/drop-zone.spec.js
+++ b/tests/unit/drop-zone.spec.js
@@ -1,4 +1,4 @@
-import { flatMap } from 'lodash';
+import flatMap from 'lodash/flatMap';
 import DropZone from '@/components/DropZone.vue';
 import { localMount } from './support';
 import Client from '../../src/client';

--- a/tests/unit/drop-zone.spec.js
+++ b/tests/unit/drop-zone.spec.js
@@ -2,6 +2,7 @@ import flatMap from 'lodash/flatMap';
 import DropZone from '@/components/DropZone.vue';
 import { localMount } from './support';
 import Client from '../../src/client';
+import XHRUpload from '@uppy/xhr-upload';
 
 function assertUppyFiles(w, expected) {
   expect(
@@ -160,9 +161,10 @@ describe('DropZone', () => {
     expect(w.vm.client.uppy.getState().files).toEqual({});
   });
 
-  test('run the drop zone in XHR mode', async () => {
+  test('change the uploader', async () => {
     expect(w.emittedByOrder().length).toBe(2);
-    w.setProps({ mode: 'XHR' });
+
+    w.setProps({ uploader: { uploaderClass: XHRUpload } });
 
     await w.vm.$nextTick();
     expect(w.vm.client.uppy.plugins.uploader.map(u => u.title))

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,14 @@
   dependencies:
     namespace-emitter "^2.0.1"
 
+"@uppy/companion-client@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/@uppy/companion-client/-/companion-client-1.7.0.tgz#aa001ba95277dd4af62852ce7efbdc85b3965d4c"
+  integrity sha512-nDE+yaSFH/DQhttwhMd6SsaifCpifY6a7HchYdCF7/eR+E2VgRYyMrNHRA7YiWVIXlhXciaU3fmDUkEicD2dww==
+  dependencies:
+    "@uppy/utils" "^3.3.0"
+    namespace-emitter "^2.0.1"
+
 "@uppy/core@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@uppy/core/-/core-1.4.0.tgz#e8dabd0dec4a2202eda8d67ea06fd050d4a541d1"
@@ -962,13 +970,21 @@
   dependencies:
     lodash.throttle "^4.1.1"
 
-"@uppy/xhr-upload@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@uppy/xhr-upload/-/xhr-upload-1.3.0.tgz#eced421737d1af275b2e096cbe6c056892256741"
-  integrity sha512-ogxRab1BpuNT5+LPdE3nBHRdmXe2p7BTi0e0eBtgAkmLtGM4bsaYXMbTuUac8xf7TCkFuFDqTVpzx7ZUzN4V9g==
+"@uppy/utils@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/@uppy/utils/-/utils-3.3.0.tgz#c9501a4f1cd98bf91fb8f5a5651b47df40ac785f"
+  integrity sha512-oPNZjjRDDBLC7763idAlzIZiaQoFq2ms/G0TOFq5YeiBv/usbvb/mcEugrwsvLAvLYum2wJzYvWzAx4tlFF/ag==
   dependencies:
-    "@uppy/companion-client" "^1.3.0"
-    "@uppy/utils" "^1.3.0"
+    abortcontroller-polyfill "^1.4.0"
+    lodash.throttle "^4.1.1"
+
+"@uppy/xhr-upload@^1.3.0":
+  version "1.6.8"
+  resolved "https://registry.npmjs.org/@uppy/xhr-upload/-/xhr-upload-1.6.8.tgz#7d2b01ee89a8e82a95aed57b7a89c5d584977747"
+  integrity sha512-ncaPBCIILkLyOqr3sNwbOe01e5YfBY8p7f1csj1V5quHIR8yg6byFUOnWyZSPfUJ5A5D+n0SJcxehhqSCaRgWA==
+  dependencies:
+    "@uppy/companion-client" "^1.7.0"
+    "@uppy/utils" "^3.3.0"
     cuid "^2.1.1"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
@@ -1386,6 +1402,11 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abortcontroller-polyfill@^1.4.0:
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.1.tgz#27084bac87d78a7224c8ee78135d05df430c2d2f"
+  integrity sha512-yml9NiDEH4M4p0G4AcPkg8AAa4mF3nfYF28VQxaokpO67j9H7gWgmsVWJ/f1Rn+PzsnDYvzJzWIQzCqDKRvWlA==
 
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"


### PR DESCRIPTION
⚠️ API Change ⚠️ 

This PR removes the predefined uploaders and allows the user to choose its own uploader by passing it through a prop.

Old API:
```
<DropZone mode="TUS" :options="{ uploader: { myUploaderProperty: true }}" />
```

New API:

```
import Tus from '@uppy/tus';

<DropZone :uploader="{ uploaderClass: Tus, options: { myUploaderProperty: true }}" />
```

In addition, it redirects all uppy props of the `upload-success` event to the `success` event. See https://uppy.io/docs/uppy/#upload-success for more information about the uppy event props